### PR TITLE
Hiring flow optimization

### DIFF
--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="card">
     <div class="card-body">
-      <%= render 'calendar', interviews: @interviews %>	
+      <%= render 'calendar', interviews: @interviews %>
     </div>
   </div>
 </div>

--- a/app/views/job_postings/_job_posting_list_item_dropdown.html.erb
+++ b/app/views/job_postings/_job_posting_list_item_dropdown.html.erb
@@ -19,11 +19,17 @@
           <li>
             <%= link_to "Begin Interviewing", interview_job_posting_path(posting) %>
           </li>
+          <li>
+            <%= link_to "Close Job Posting", close_job_posting_path(posting) %>
+          </li>
         <% end %>
       <% else %>
         <% if posting.status == "open" %>
           <li>
             <%= link_to "Begin Interviewing", interview_job_posting_path(posting) %>
+          </li>
+          <li>
+            <%= link_to "Close Job Posting", close_job_posting_path(posting) %>
           </li>
         <% else %>
           <li>

--- a/app/views/job_postings/_job_posting_list_item_dropdown_admin.html.erb
+++ b/app/views/job_postings/_job_posting_list_item_dropdown_admin.html.erb
@@ -18,6 +18,9 @@
         <li>
           <%= link_to "Begin Interviewing", interview_job_posting_path(posting) %>
         </li>
+				<li>
+					<%= link_to "Close Job Posting", close_job_posting_path(posting) %>
+				</li>
       <% end %>
       <li>
         <%= link_to "Edit Posting", edit_job_posting_path(posting.id) %>

--- a/app/views/job_postings/_job_posting_status_button.html.erb
+++ b/app/views/job_postings/_job_posting_status_button.html.erb
@@ -1,7 +1,13 @@
 <% if posting.status != "closed" %>
-  <%= link_to close_job_posting_path(posting), class: "btn btn-primary", :"data-html" => "true", :"data-toggle" => "popover", :"data-content" => "Close the job posting, and decline all applicants who were not hired.<br /><br /> Select this after the job has been filled.", :"data-title" => "Closing a Job Posting", :"data-trigger" => "hover", :"data-placement" => "auto", data: { :confirm => "Are you sure you're finished with this job posting?" } do %>
-    <em class="ion-android-checkmark-circle icon-lg mr-sm"></em>Close Job Posting
-  <% end %>
+	<% if posting.status != "interviewing"%>
+	  <%= link_to interview_job_posting_path(posting), class: "btn btn-primary" do %>
+		<em class="ion-android-checkmark-circle icon-lg mr-sm"></em>Begin Interviewing
+	  <% end %>
+	<% else %>
+	  <%= link_to close_job_posting_path(posting), class: "btn btn-primary", :"data-html" => "true", :"data-toggle" => "popover", :"data-content" => "Close the job posting, and decline all applicants who were not hired.<br /><br /> Select this after the job has been filled.", :"data-title" => "Closing a Job Posting", :"data-trigger" => "hover", :"data-placement" => "auto", data: { :confirm => "Are you sure you're finished with this job posting?" } do %>
+	    <em class="ion-android-checkmark-circle icon-lg mr-sm"></em>Close Job Posting
+	  <% end %>
+	<% end %>
 <% else %>
   <%= link_to reopen_job_posting_path(posting), class: "btn btn-warning", :"data-html" => "true", :"data-toggle" => "popover", :"data-content" => "Reopen the job posting, and archive all previous applicants.<br /><br /> Select this to restart the hiring process using the same job and job posting details.", :"data-title" => "Reopening a Job Posting", :"data-trigger" => "hover", :"data-placement" => "auto", data: { :confirm => "Are you sure you want to begin hiring for this job posting?" } do %>
     <em class="ion-android-checkmark-circle icon-lg mr-sm"></em>Reopen Job Posting


### PR DESCRIPTION
## Proposed Change

Fixes: Tweaked workflow when people are managing their job postings.

### How did you do this?
Modified the 'Close Job Posting' Button. It will now say 'Begin Interviewing' when the status of the application is 'Open' and will begin interviewing if clicked and if the posting is passed its due date. Once the status is 'Interviewing', the button will read 'Close Job Posting' and function as before. Should the use need to close the job posting without interviewing, the option to close is found in the dropdown menu where they would begin interviewing before.

### Why are you choosing this approach?
I felt it was a better workflow. There were also only a few .html.erb file changes needed.

### Any open questions you want to ask code reviewers?
Do you have a better idea for workflow or see any problems with this approach?

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

